### PR TITLE
feat(portability): add support for FreeBSD

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -312,7 +312,7 @@ jobs:
           run: |
             /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
             cp "${HOME}/.bitcoin/debug.log" .
-      - name: If test failed, debug nodebuilder ${{ matrix.additional-args }}
+      - name: If test failed, debug nodebuilder
         if: steps.test-nodebuilder.outcome == 'failure'
         uses: vmactions/freebsd-vm@v1
         timeout-minutes: 180

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -309,8 +309,6 @@ jobs:
           run: |
             /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
             cp "${HOME}/.bitcoin/debug.log" .
-      - name: Search for path for Bitcoin Core debug.log
-        run: find / -type f -name 'debug.log' 2> /dev/null || true
       - name: Save Bitcoin Core log as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -308,6 +308,7 @@ jobs:
             date -u
           run: |
             /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
+            find / -type f -name debug.log 2>/dev/null
             cp "${HOME}/.bitcoon/debug.log" .
       - name: Search for path for Bitcoin Core debug.log
         run: find / -type f -name 'debug.log' 2> /dev/null || true

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -308,7 +308,7 @@ jobs:
             date -u
           run: /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
       - name: Search for path for Bitcoin Core debug.log
-        run: find / -type d -name '.bitcoin'
+        run: find / -type f -name 'debug.log' 2> /dev/null || true
       - name: Save Bitcoin Core log as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -308,7 +308,7 @@ jobs:
             date -u
           run: |
             /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
-            cp "$(HOME)/.bitcoon/debug.log" .
+            cp "${HOME}/.bitcoon/debug.log" .
       - name: Search for path for Bitcoin Core debug.log
         run: find / -type f -name 'debug.log' 2> /dev/null || true
       - name: Save Bitcoin Core log as artifact

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -309,7 +309,7 @@ jobs:
             date -u
           run: |
             /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
-            cp "${HOME}/.bitcoin/debug.log" .
+            [ -f "${HOME}/.bitcoin/debug.log" ] && cp "${HOME}/.bitcoin/debug.log" .
       - name: Save Bitcoin Core log as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -297,10 +297,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test the console output
-        id: test-nodebuilder
         uses: vmactions/freebsd-vm@v1
         timeout-minutes: 180
-        continue-on-error: true
         with:
           prepare: |
             uname -a
@@ -312,33 +310,11 @@ jobs:
           run: |
             /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
             cp "${HOME}/.bitcoin/debug.log" .
-      - name: If test failed, debug nodebuilder
-        if: steps.test-nodebuilder.outcome == 'failure'
-        uses: vmactions/freebsd-vm@v1
-        timeout-minutes: 180
-        env:
-            CI_NODEBUILDER_URL: https://github.com/bitcoin-tools/nodebuilder/raw/master/nodebuilder
-        with:
-          prepare: pkg install --yes wget
-          envs: 'CI_NODEBUILDER_URL'
-          run: |
-            if [ -n "$(ls /usr/local/bin/*bitcoin*)" ]; then
-              rm /usr/local/bin/*bitcoin*
-            fi
-            wget --no-verbose --retry-connrefused "${CI_NODEBUILDER_URL}"
-            chmod u+x nodebuilder
-            /bin/sh -x ./nodebuilder
-            cp "${HOME}/.bitcoin/debug.log" ./rerun-debug.log
       - name: Save Bitcoin Core log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: freebsd-source-bitcoin-debug.log
-          path: |
-            /home/runner/work/nodebuilder/nodebuilder/debug.log
-            /home/runner/work/nodebuilder/nodebuilder/rerun-debug.log
-      - name: If test failed, fail the job
-        if: steps.test-nodebuilder.outcome == 'failure'
-        run: printf '%s\n' "Review the step 'Test the console output' above." && exit 1
+          path: /home/runner/work/nodebuilder/nodebuilder/debug.log
 
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -282,7 +282,7 @@ jobs:
         if: steps.test-nodebuilder.outcome == 'failure'
         run: printf '%s\n' "Review the step 'Test the console output' above." && exit 1
 
-  run-nodebuilder-freebsd-vm:
+  run-nodebuilder-freebsd:
     name: Test source on FreeBSD
     needs: [changes, shell-lint, yaml-lint]
     if: >-
@@ -296,19 +296,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check the current environment
-        run: |
-          uname -a
-          cat /etc/os-release
-          nproc
-          sysctl -a | grep ' memory' | head -2
-          df -h
-          date -u
       - name: Test nodebuilder in FreeBSD
         uses: vmactions/freebsd-vm@v1
         with:
-          prepare: pkg install -y curl
+          prepare: |
+            uname -a
+            cat /etc/os-release
+            nproc
+            sysctl -a | grep ' memory' | head -2
+            df -h
+            date -u
           run: ./nodebuilder
+          sync: no
 
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -315,7 +315,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: freebsd-source-bitcoin-debug.log
-          path: /home/runner/.bitcoin/debug.log
+          path: /home/runner/work/nodebuilder/nodebuilder/debug.log
 
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -284,6 +284,7 @@ jobs:
 
   run-nodebuilder-freebsd-vm:
     name: Test nodebuilder on FreeBSD
+    needs: [changes, shell-lint, yaml-lint]
     if: >-
       ${{
         github.event.action == 'prerelease' ||

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -308,8 +308,7 @@ jobs:
             date -u
           run: |
             /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
-            find / -type f -name debug.log 2>/dev/null
-            cp "${HOME}/.bitcoon/debug.log" .
+            cp "${HOME}/.bitcoin/debug.log" .
       - name: Search for path for Bitcoin Core debug.log
         run: find / -type f -name 'debug.log' 2> /dev/null || true
       - name: Save Bitcoin Core log as artifact

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -282,6 +282,33 @@ jobs:
         if: steps.test-nodebuilder.outcome == 'failure'
         run: printf '%s\n' "Review the step 'Test the console output' above." && exit 1
 
+  run-nodebuilder-freebsd-vm:
+    name: Test nodebuilder on FreeBSD
+    if: >-
+      ${{
+        github.event.action == 'prerelease' ||
+        github.event.action == 'published' ||
+        needs.changes.outputs.ci == 'true' ||
+        needs.changes.outputs.dependencies == 'true' ||
+        needs.changes.outputs.shell == 'true'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check the current environment
+        run: |
+          uname -a
+          cat /etc/os-release
+          nproc
+          sysctl -a | grep ' memory' | head -2
+          df -h
+          date -u
+      - name: Test nodebuilder in FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          prepare: pkg install -y curl
+          run: ./nodebuilder --ref "${GITHUB_SHA}"
+
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}
     needs: [changes, dockerfile-lint, shell-lint, yaml-lint]

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -307,6 +307,8 @@ jobs:
             df -h
             date -u
           run: /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
+      - name: Search for path for Bitcoin Core debug.log
+        run: find / -type d -name '.bitcoin'
       - name: Save Bitcoin Core log as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -307,7 +307,6 @@ jobs:
             df -h
             date -u
           run: ./nodebuilder
-          sync: no
 
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -307,6 +307,12 @@ jobs:
             df -h
             date -u
           run: ./nodebuilder
+      - name: Save Bitcoin Core log as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: freebsd-source-bitcoin-debug.log
+          path: /home/runner/.bitcoin/debug.log
+
 
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -283,7 +283,7 @@ jobs:
         run: printf '%s\n' "Review the step 'Test the console output' above." && exit 1
 
   run-nodebuilder-freebsd-vm:
-    name: Test nodebuilder on FreeBSD
+    name: Test source on FreeBSD
     needs: [changes, shell-lint, yaml-lint]
     if: >-
       ${{

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -297,7 +297,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test the console output
+        id: test-nodebuilder
         uses: vmactions/freebsd-vm@v1
+        timeout-minutes: 180
+        continue-on-error: true
         with:
           prepare: |
             uname -a
@@ -309,11 +312,31 @@ jobs:
           run: |
             /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
             cp "${HOME}/.bitcoin/debug.log" .
+      - name: If test failed, debug nodebuilder ${{ matrix.additional-args }}
+        if: steps.test-nodebuilder.outcome == 'failure'
+        uses: vmactions/freebsd-vm@v1
+        timeout-minutes: 180
+        env:
+            CI_NODEBUILDER_URL: https://github.com/bitcoin-tools/nodebuilder/raw/master/nodebuilder
+        with:
+          prepare: pkg install --yes wget
+          envs: 'CI_NODEBUILDER_URL'
+          run: |
+            if [ -n "$(ls /usr/local/bin/*bitcoin*)" ]; then
+              rm /usr/local/bin/*bitcoin*
+            fi
+            wget --no-verbose --retry-connrefused "${CI_NODEBUILDER_URL}"
+            chmod u+x nodebuilder
+            /bin/sh -x ./nodebuilder ${{ matrix.additional-args }}
+            cp "${HOME}/.bitcoin/debug.log" .
       - name: Save Bitcoin Core log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: freebsd-source-bitcoin-debug.log
           path: /home/runner/work/nodebuilder/nodebuilder/debug.log
+      - name: If test failed, fail the job
+        if: steps.test-nodebuilder.outcome == 'failure'
+        run: printf '%s\n' "Review the step 'Test the console output' above." && exit 1
 
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -306,7 +306,9 @@ jobs:
             sysctl -a | grep ' memory' | head -2
             df -h
             date -u
-          run: /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
+          run: |
+            /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
+            cp "$(HOME)/.bitcoon/debug.log" .
       - name: Search for path for Bitcoin Core debug.log
         run: find / -type f -name 'debug.log' 2> /dev/null || true
       - name: Save Bitcoin Core log as artifact

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -308,7 +308,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           prepare: pkg install -y curl
-          run: ./nodebuilder --ref "${GITHUB_SHA}"
+          run: ./nodebuilder
 
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Test nodebuilder in FreeBSD
+      - name: Test the console output
         uses: vmactions/freebsd-vm@v1
         with:
           prepare: |
@@ -306,7 +306,7 @@ jobs:
             sysctl -a | grep ' memory' | head -2
             df -h
             date -u
-          run: ./nodebuilder
+          run: /bin/sh -x ./test/test_nodebuilder --ref "${GITHUB_SHA}"
       - name: Save Bitcoin Core log as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -327,13 +327,15 @@ jobs:
             fi
             wget --no-verbose --retry-connrefused "${CI_NODEBUILDER_URL}"
             chmod u+x nodebuilder
-            /bin/sh -x ./nodebuilder ${{ matrix.additional-args }}
-            cp "${HOME}/.bitcoin/debug.log" .
+            /bin/sh -x ./nodebuilder
+            cp "${HOME}/.bitcoin/debug.log" ./rerun-debug.log
       - name: Save Bitcoin Core log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: freebsd-source-bitcoin-debug.log
-          path: /home/runner/work/nodebuilder/nodebuilder/debug.log
+          path: |
+            /home/runner/work/nodebuilder/nodebuilder/debug.log
+            /home/runner/work/nodebuilder/nodebuilder/rerun-debug.log
       - name: If test failed, fail the job
         if: steps.test-nodebuilder.outcome == 'failure'
         run: printf '%s\n' "Review the step 'Test the console output' above." && exit 1

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -318,7 +318,6 @@ jobs:
           name: freebsd-source-bitcoin-debug.log
           path: /home/runner/.bitcoin/debug.log
 
-
   run-nodebuilder-docker:
     name: Docker image for ${{ matrix.container }}
     needs: [changes, dockerfile-lint, shell-lint, yaml-lint]

--- a/nodebuilder
+++ b/nodebuilder
@@ -71,7 +71,7 @@ compile_bitcoin_from_source() {
     ./configure CC=clang CXX=clang++ --without-bdb --enable-suppress-external-warnings > /dev/null ;;
   'FreeBSD')
     # TODO: suppress stdout
-    ./configure --without-bdb ==enable-suppress-external-warnings MAKE=gmake ;;
+    ./configure --without-bdb --enable-suppress-external-warnings MAKE=gmake ;;
   *)
     ./configure --without-bdb --enable-suppress-external-warnings > /dev/null ;;
   esac

--- a/nodebuilder
+++ b/nodebuilder
@@ -76,6 +76,8 @@ compile_bitcoin_from_source() {
     ./configure --without-bdb --enable-suppress-external-warnings > /dev/null ;;
   esac
   log_info 'Compiling source code. Please wait.'
+  echo "DEBUG SYS_CORES_COUNT: ${SYS_CORES_COUNT}"
+  echo "DEBUG SYS_CORES_PLUS_ONE: ${SYS_CORES_PLUS_ONE}"
   make --jobs "${SYS_CORES_PLUS_ONE}"
   log_info 'Running compile checks. Please wait.'
   make --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"

--- a/nodebuilder
+++ b/nodebuilder
@@ -80,13 +80,13 @@ compile_bitcoin_from_source() {
   log_info 'Compiling source code. Please wait.'
   echo "DEBUG SYS_CORES_COUNT: ${SYS_CORES_COUNT}"
   echo "DEBUG SYS_CORES_PLUS_ONE: ${SYS_CORES_PLUS_ONE}"
-  if [ "${TARGET_KERNEL}" == 'FreeBSD' ]; then
+  if [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then
     gmake --jobs "${SYS_CORES_PLUS_ONE}"
   else
     make --jobs "${SYS_CORES_PLUS_ONE}"
   fi
   log_info 'Running compile checks. Please wait.'
-  if [ "${TARGET_KERNEL}" == 'FreeBSD' ]; then
+  if [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then
     gmake --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
   else
     make --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"

--- a/nodebuilder
+++ b/nodebuilder
@@ -515,7 +515,7 @@ install_build_dependencies_emerge() {
 }
 
 install_build_dependencies_freebsd() {
-  readonly BUILD_DEPENDENCIES_URL="${DEBUG_ONLY_FREEBSD_DEPENDENCIES_BASE_URL}/build_dependencies_freebsd.txt"
+  readonly BUILD_DEPENDENCIES_URL="${FREEBSD_DEPENDENCIES_BASE_URL}/build_dependencies_freebsd.txt"
   command -v torsocks > /dev/null 2>&1 &&
     dependencies=$(torsocks curl --fail --silent --show-error --location --retry 2 "${BUILD_DEPENDENCIES_URL}") ||
     dependencies=$(curl --fail --silent --show-error --location --retry 5 "${BUILD_DEPENDENCIES_URL}")
@@ -679,7 +679,7 @@ install_runtime_dependencies_emerge() {
 }
 
 install_runtime_dependencies_freebsd() {
-  readonly RUNTIME_DEPENDENCIES_URL="${DEBUG_ONLY_FREEBSD_DEPENDENCIES_BASE_URL}/runtime_dependencies_freebsd.txt"
+  readonly RUNTIME_DEPENDENCIES_URL="${FREEBSD_DEPENDENCIES_BASE_URL}/runtime_dependencies_freebsd.txt"
   command -v torsocks > /dev/null 2>&1 &&
     dependencies=$(torsocks curl --fail --silent --show-error --location --retry 2 "${RUNTIME_DEPENDENCIES_URL}") ||
     dependencies=$(curl --fail --silent --show-error --location --retry 5 "${RUNTIME_DEPENDENCIES_URL}")
@@ -1070,7 +1070,7 @@ readonly BITCOIN_CORE_REPO='https://github.com/bitcoin/bitcoin'
 readonly NODEBUILDER_REPO='https://github.com/bitcoin-tools/nodebuilder'
 readonly NODEBUILDER_DEPENDENCIES_TAG='v1.7.1-beta'
 readonly DEPENDENCIES_BASE_URL="${NODEBUILDER_REPO}/raw/${NODEBUILDER_DEPENDENCIES_TAG}/resources/dependencies"
-readonly DEBUG_ONLY_FREEBSD_DEPENDENCIES_BASE_URL="${NODEBUILDER_REPO}/raw/251-add-freebsd-support/resources/dependencies"
+readonly FREEBSD_DEPENDENCIES_BASE_URL="${NODEBUILDER_REPO}/raw/master/resources/dependencies"
 
 case "${TARGET_KERNEL}" in
 Linux | FreeBSD)

--- a/nodebuilder
+++ b/nodebuilder
@@ -1555,7 +1555,7 @@ while [ "${ibd_status}" = 'true' ]; do
     printf 'Sync progress:              %.3f %%\n' "${sync_progress_percent}"
     printf 'Blocks remaining:           %d\n' "$((headers - blocks))"
 
-    if [ "${TARGET_KERNEL}" = 'Darwin' ]; then
+    if [ "${TARGET_KERNEL}" = 'Darwin' ] || [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then
       current_chain_tip_timestamp="$(/bin/date -r "${last_block_time}" | cut -c 5-)"
     else
       current_chain_tip_timestamp="$(date -d @"${last_block_time}" | cut -c 5-)"

--- a/nodebuilder
+++ b/nodebuilder
@@ -80,9 +80,9 @@ compile_bitcoin_from_source() {
   log_info 'Compiling source code. Please wait.'
   echo "DEBUG SYS_CORES_COUNT: ${SYS_CORES_COUNT}"
   echo "DEBUG SYS_CORES_PLUS_ONE: ${SYS_CORES_PLUS_ONE}"
-  make -j${SYS_CORES_PLUS_ONE}
+  make --jobs ${SYS_CORES_PLUS_ONE}
   log_info 'Running compile checks. Please wait.'
-  make -j "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
+  make --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
   # exclude the two lines before and after 'Ran 3 tests in ' in make check's stdout
   sed -n '1N;2N;/Ran 3 tests in /{N;N;d;};P;N;D' "${STDERR_COMPILE_LOG_FILE}" >&2
   log_info 'Installing Bitcoin Core.'

--- a/nodebuilder
+++ b/nodebuilder
@@ -520,7 +520,7 @@ install_build_dependencies_freebsd() {
     dependencies=$(torsocks curl --fail --silent --show-error --location --retry 2 "${BUILD_DEPENDENCIES_URL}") ||
     dependencies=$(curl --fail --silent --show-error --location --retry 5 "${BUILD_DEPENDENCIES_URL}")
   [ -z "${dependencies:-}" ] && throw_error "The list of dependencies is empty."
-  printf '%s\n' "${dependencies}" | xargs sudo pkg install -y > /dev/null
+  printf '%s\n' "${dependencies}" | xargs sudo pkg install --yes > /dev/null
 }
 
 install_build_dependencies_pacman() {
@@ -684,7 +684,7 @@ install_runtime_dependencies_freebsd() {
     dependencies=$(torsocks curl --fail --silent --show-error --location --retry 2 "${RUNTIME_DEPENDENCIES_URL}") ||
     dependencies=$(curl --fail --silent --show-error --location --retry 5 "${RUNTIME_DEPENDENCIES_URL}")
   [ -z "${dependencies}" ] && throw_error 'The list of dependencies is empty.'
-  printf '%s\n' "${dependencies}" | xargs sudo pkg install -y > /dev/null
+  printf '%s\n' "${dependencies}" | xargs sudo pkg install --yes > /dev/null
 }
 
 install_runtime_dependencies_pacman() {
@@ -824,7 +824,7 @@ install_system_updates_emerge() {
 }
 
 install_system_updates_freebsd() {
-  sudo pkg update -f > /dev/null
+  sudo pkg update > /dev/null
   sudo pkg upgrade --yes > /dev/null
 }
 

--- a/nodebuilder
+++ b/nodebuilder
@@ -1181,7 +1181,7 @@ if [ "${CURRENT_BITCOIN_VERSION_PADDED}" = "${TARGET_BITCOIN_VERSION_PADDED}" ];
 elif [ "${compile_bitcoin_flag:-false}" = 'true' ] ||
   [ "${TARGET_OPERATING_SYSTEM}" = 'alpine' ] ||
   [ "${TARGET_OPERATING_SYSTEM}" = 'gentoo' ] ||
-  [ "${TARGET_OPERATING_SYSTEM}" = 'FreeBSD' ] ||; then
+  [ "${TARGET_OPERATING_SYSTEM}" = 'FreeBSD' ]; then
   log_info "Failed to find Bitcoin Core ${target_bitcoin_version}."
   compile_bitcoin_from_source
   current_bitcoin_version="${target_bitcoin_version}"

--- a/nodebuilder
+++ b/nodebuilder
@@ -68,12 +68,14 @@ compile_bitcoin_from_source() {
   log_info 'Configuring the build environment.'
   case "${TARGET_KERNEL}" in
   'Darwin')
-    ./configure CC=clang CXX=clang++ --without-bdb --enable-suppress-external-warnings > /dev/null ;;
+    ./configure CC=clang CXX=clang++ --without-bdb --enable-suppress-external-warnings > /dev/null
+    ;;
   'FreeBSD')
-    # TODO: suppress stdout
-    ./configure --without-bdb --enable-suppress-external-warnings MAKE=gmake ;;
+    ./configure --without-bdb --enable-suppress-external-warnings MAKE=gmake > /dev/null
+    ;;
   *)
-    ./configure --without-bdb --enable-suppress-external-warnings > /dev/null ;;
+    ./configure --without-bdb --enable-suppress-external-warnings > /dev/null
+    ;;
   esac
   log_info 'Compiling source code. Please wait.'
   echo "DEBUG SYS_CORES_COUNT: ${SYS_CORES_COUNT}"

--- a/nodebuilder
+++ b/nodebuilder
@@ -66,11 +66,15 @@ compile_bitcoin_from_source() {
   ./autogen.sh > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
   grep -v 'build-aux' "${STDERR_COMPILE_LOG_FILE}" >&2 || true
   log_info 'Configuring the build environment.'
-  if [ "${TARGET_KERNEL}" = 'Darwin' ]; then
-    ./configure CC=clang CXX=clang++ --without-bdb --enable-suppress-external-warnings > /dev/null
-  else
-    ./configure --without-bdb --enable-suppress-external-warnings > /dev/null
-  fi
+  case "${TARGET_KERNEL}" in
+  'Darwin')
+    ./configure CC=clang CXX=clang++ --without-bdb --enable-suppress-external-warnings > /dev/null ;;
+  'FreeBSD')
+    # TODO: suppress stdout
+    ./configure --without-bdb ==enable-suppress-external-warnings MAKE=gmake ;;
+  *)
+    ./configure --without-bdb --enable-suppress-external-warnings > /dev/null ;;
+  esac
   log_info 'Compiling source code. Please wait.'
   make --jobs "${SYS_CORES_PLUS_ONE}" > /dev/null 2>&1
   log_info 'Running compile checks. Please wait.'

--- a/nodebuilder
+++ b/nodebuilder
@@ -1056,14 +1056,11 @@ readonly DEPENDENCIES_BASE_URL="${NODEBUILDER_REPO}/raw/${NODEBUILDER_DEPENDENCI
 readonly DEBUG_ONLY_FREEBSD_DEPENDENCIES_BASE_URL="${NODEBUILDER_REPO}/raw/251-add-freebsd-support/resources/dependencies"
 
 case "${TARGET_KERNEL}" in
-Linux)
+Linux | FreeBSD)
   SYS_CORES_COUNT="$(nproc)"
   ;;
 Darwin)
   SYS_CORES_COUNT="$(sysctl -n hw.physicalcpu)"
-  ;;
-FreeBSD)
-  SYS_CORES_COUNT="$(sysctl -n hw.ncpu)"
   ;;
 MINGW* | Cygwin)
   throw_error 'Windows is not supported. Use Linux, macOS, or Windows Subsystem for Linux instead.'

--- a/nodebuilder
+++ b/nodebuilder
@@ -340,7 +340,7 @@ ensure_xargs_dependency() {
 get_free_space_in_mib() {
   case "${TARGET_KERNEL}" in
   'Darwin' | 'FreeBSD')
-    /bin/df -m "${HOME}" | awk '{print $4}' | sed 1d 
+    /bin/df -m "${HOME}" | awk '{print $4}' | sed 1d
     ;;
   *)
     df --output=avail --block-size='1MiB' "${HOME}" | sed 1d

--- a/nodebuilder
+++ b/nodebuilder
@@ -76,7 +76,7 @@ compile_bitcoin_from_source() {
     ./configure --without-bdb --enable-suppress-external-warnings > /dev/null ;;
   esac
   log_info 'Compiling source code. Please wait.'
-  make --jobs "${SYS_CORES_PLUS_ONE}" > /dev/null 2>&1
+  make --jobs "${SYS_CORES_PLUS_ONE}"
   log_info 'Running compile checks. Please wait.'
   make --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
   # exclude the two lines before and after 'Ran 3 tests in ' in make check's stdout

--- a/nodebuilder
+++ b/nodebuilder
@@ -1496,10 +1496,11 @@ ibd_status=$(echo "${blockchain_info}" | jq '.initialblockdownload')
 
 if [ "${ibd_status}" = 'true' ]; then
   if ! is_running_in_container; then
-    log_info 'Disabling system sleep, suspend, and hibernate.'
     if [ "${TARGET_KERNEL}" = 'Darwin' ]; then
+      log_info 'Disabling system sleep, suspend, and hibernate.'
       caffeinate -sw "$(cat "${BITCOIN_DATA_DIRECTORY}/bitcoind.pid")" &
-    else
+    elif [ "${TARGET_KERNEL}" = 'Linux' ]; then
+      log_info 'Disabling system sleep, suspend, and hibernate.'
       sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target > /dev/null 2>&1
     fi
     log_info "Close this Terminal window by clicking on the 'X'."

--- a/nodebuilder
+++ b/nodebuilder
@@ -1180,7 +1180,8 @@ if [ "${CURRENT_BITCOIN_VERSION_PADDED}" = "${TARGET_BITCOIN_VERSION_PADDED}" ];
   log_info "Found Bitcoin Core ${target_bitcoin_version}."
 elif [ "${compile_bitcoin_flag:-false}" = 'true' ] ||
   [ "${TARGET_OPERATING_SYSTEM}" = 'alpine' ] ||
-  [ "${TARGET_OPERATING_SYSTEM}" = 'gentoo' ]; then
+  [ "${TARGET_OPERATING_SYSTEM}" = 'gentoo' ] ||
+  [ "${TARGET_OPERATING_SYSTEM}" = 'FreeBSD' ] ||; then
   log_info "Failed to find Bitcoin Core ${target_bitcoin_version}."
   compile_bitcoin_from_source
   current_bitcoin_version="${target_bitcoin_version}"

--- a/nodebuilder
+++ b/nodebuilder
@@ -71,7 +71,7 @@ compile_bitcoin_from_source() {
     ./configure CC=clang CXX=clang++ --without-bdb --enable-suppress-external-warnings > /dev/null
     ;;
   'FreeBSD')
-    ./configure --without-bdb --enable-suppress-external-warnings MAKE=gmake > /dev/null
+    ./configure --without-bdb --enable-suppress-external-warnings MAKE=gmake > "${HOME}/configure_results"
     ;;
   *)
     ./configure --without-bdb --enable-suppress-external-warnings > /dev/null

--- a/nodebuilder
+++ b/nodebuilder
@@ -1116,7 +1116,7 @@ Darwin)
   [ "${TARGET_ARCHITECTURE}" = 'arm64' ] && display_macos_warning
   ;;
 FreeBSD)
-  TARGET_BITCOIN_TARBALL_OS=''
+  TARGET_BITCOIN_TARBALL_OS='linux-gnu'
   BITCOIN_DATA_DIRECTORY="${HOME}/.bitcoin"
   log_info "Detected: running FreeBSD."
   ;;
@@ -1180,8 +1180,7 @@ if [ "${CURRENT_BITCOIN_VERSION_PADDED}" = "${TARGET_BITCOIN_VERSION_PADDED}" ];
   log_info "Found Bitcoin Core ${target_bitcoin_version}."
 elif [ "${compile_bitcoin_flag:-false}" = 'true' ] ||
   [ "${TARGET_OPERATING_SYSTEM}" = 'alpine' ] ||
-  [ "${TARGET_OPERATING_SYSTEM}" = 'gentoo' ] ||
-  [ "${TARGET_OPERATING_SYSTEM}" = 'FreeBSD' ]; then
+  [ "${TARGET_OPERATING_SYSTEM}" = 'gentoo' ]; then
   log_info "Failed to find Bitcoin Core ${target_bitcoin_version}."
   compile_bitcoin_from_source
   current_bitcoin_version="${target_bitcoin_version}"

--- a/nodebuilder
+++ b/nodebuilder
@@ -1103,25 +1103,20 @@ fi
 
 clear_the_terminal
 case "${TARGET_KERNEL}" in
-Linux)
+Linux | FreeBSD)
   TARGET_BITCOIN_TARBALL_OS='linux-gnu'
   BITCOIN_DATA_DIRECTORY="${HOME}/.bitcoin"
-  log_info 'Detected: running Linux.'
+  log_info "Detected: running ${TARGET_KERNEL}."
   is_running_in_container && log_info 'Detected: running in Docker.'
   ;;
 Darwin)
   TARGET_BITCOIN_TARBALL_OS='apple-darwin'
   BITCOIN_DATA_DIRECTORY="${HOME}/Library/Application Support/Bitcoin"
-  log_info "Detected: running macOS."
+  log_info 'Detected: running macOS.'
   [ "${TARGET_ARCHITECTURE}" = 'arm64' ] && display_macos_warning
   ;;
-FreeBSD)
-  TARGET_BITCOIN_TARBALL_OS='linux-gnu'
-  BITCOIN_DATA_DIRECTORY="${HOME}/.bitcoin"
-  log_info "Detected: running FreeBSD."
-  ;;
 *)
-  throw_error 'Unknown target kernel type.'
+  throw_error "Unknown target kernel type '${TARGET_KERNEL}'."
   ;;
 esac
 

--- a/nodebuilder
+++ b/nodebuilder
@@ -345,7 +345,7 @@ get_free_space_in_mib() {
   *)
     df --output=avail --block-size='1MiB' "${HOME}" | sed 1d
     ;;
-  fi
+  esac
 }
 
 get_log_timestamp() {

--- a/nodebuilder
+++ b/nodebuilder
@@ -80,9 +80,17 @@ compile_bitcoin_from_source() {
   log_info 'Compiling source code. Please wait.'
   echo "DEBUG SYS_CORES_COUNT: ${SYS_CORES_COUNT}"
   echo "DEBUG SYS_CORES_PLUS_ONE: ${SYS_CORES_PLUS_ONE}"
-  make --jobs ${SYS_CORES_PLUS_ONE}
+  if [ "${TARGET_KERNEL}" == 'FreeBSD' ]; then
+    gmake --jobs "${SYS_CORES_PLUS_ONE}"
+  else
+    make --jobs "${SYS_CORES_PLUS_ONE}"
+  fi
   log_info 'Running compile checks. Please wait.'
-  make --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
+  if [ "${TARGET_KERNEL}" == 'FreeBSD' ]; then
+    gmake --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
+  else
+    make --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
+  fi
   # exclude the two lines before and after 'Ran 3 tests in ' in make check's stdout
   sed -n '1N;2N;/Ran 3 tests in /{N;N;d;};P;N;D' "${STDERR_COMPILE_LOG_FILE}" >&2
   log_info 'Installing Bitcoin Core.'

--- a/nodebuilder
+++ b/nodebuilder
@@ -338,10 +338,13 @@ ensure_xargs_dependency() {
 }
 
 get_free_space_in_mib() {
-  if [ "${TARGET_KERNEL}" = 'Darwin' ]; then
-    /bin/df -m "${HOME}" | awk '{print $4}' | sed 1d
-  else
+  case "${TARGET_KERNEL}" in
+  'Darwin' | 'FreeBSD')
+    /bin/df -m "${HOME}" | awk '{print $4}' | sed 1d 
+    ;;
+  *)
     df --output=avail --block-size='1MiB' "${HOME}" | sed 1d
+    ;;
   fi
 }
 

--- a/nodebuilder
+++ b/nodebuilder
@@ -1442,7 +1442,7 @@ elif ! grep -q -i '^prune=' "${BITCOIN_CORE_CONFIG_FILE}"; then
 fi
 
 case "${TARGET_KERNEL}" in
-Darwin) ;; #TODO: Add macOS memory check
+Darwin) ;;  #TODO: Add macOS memory check
 FreeBSD) ;; #TODO: Add FreeBSD memory check
 *)
   PHYSICAL_MEMORY_TOTAL_IN_MIB="$(get_memory_metric_in_mib 'MemTotal')" && readonly PHYSICAL_MEMORY_TOTAL_IN_MIB

--- a/nodebuilder
+++ b/nodebuilder
@@ -1441,9 +1441,9 @@ elif ! grep -q -i '^prune=' "${BITCOIN_CORE_CONFIG_FILE}"; then
   fi
 fi
 
-# PRUNING
 case "${TARGET_KERNEL}" in
 Darwin) ;; #TODO: Add macOS memory check
+FreeBSD) ;; #TODO: Add FreeBSD memory check
 *)
   PHYSICAL_MEMORY_TOTAL_IN_MIB="$(get_memory_metric_in_mib 'MemTotal')" && readonly PHYSICAL_MEMORY_TOTAL_IN_MIB
   PHYSICAL_MEMORY_FREE_IN_MIB="$(get_memory_metric_in_mib 'MemAvailable')" && readonly PHYSICAL_MEMORY_FREE_IN_MIB

--- a/nodebuilder
+++ b/nodebuilder
@@ -78,8 +78,6 @@ compile_bitcoin_from_source() {
     ;;
   esac
   log_info 'Compiling source code. Please wait.'
-  echo "DEBUG SYS_CORES_COUNT: ${SYS_CORES_COUNT}"
-  echo "DEBUG SYS_CORES_PLUS_ONE: ${SYS_CORES_PLUS_ONE}"
   if [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then
     gmake --jobs "${SYS_CORES_PLUS_ONE}" > /dev/null 2>&1
   else

--- a/nodebuilder
+++ b/nodebuilder
@@ -81,9 +81,9 @@ compile_bitcoin_from_source() {
   echo "DEBUG SYS_CORES_COUNT: ${SYS_CORES_COUNT}"
   echo "DEBUG SYS_CORES_PLUS_ONE: ${SYS_CORES_PLUS_ONE}"
   if [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then
-    gmake --jobs "${SYS_CORES_PLUS_ONE}"
+    gmake --jobs "${SYS_CORES_PLUS_ONE}" > /dev/null 2>&1
   else
-    make --jobs "${SYS_CORES_PLUS_ONE}"
+    make --jobs "${SYS_CORES_PLUS_ONE}" > /dev/null 2>&1
   fi
   log_info 'Running compile checks. Please wait.'
   if [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then

--- a/nodebuilder
+++ b/nodebuilder
@@ -1442,8 +1442,8 @@ elif ! grep -q -i '^prune=' "${BITCOIN_CORE_CONFIG_FILE}"; then
 fi
 
 case "${TARGET_KERNEL}" in
-Darwin) ;;  #TODO: Add macOS memory check
-FreeBSD) ;; #TODO: Add FreeBSD memory check
+Darwin) ;;
+FreeBSD) ;;
 *)
   PHYSICAL_MEMORY_TOTAL_IN_MIB="$(get_memory_metric_in_mib 'MemTotal')" && readonly PHYSICAL_MEMORY_TOTAL_IN_MIB
   PHYSICAL_MEMORY_FREE_IN_MIB="$(get_memory_metric_in_mib 'MemAvailable')" && readonly PHYSICAL_MEMORY_FREE_IN_MIB

--- a/nodebuilder
+++ b/nodebuilder
@@ -80,9 +80,9 @@ compile_bitcoin_from_source() {
   log_info 'Compiling source code. Please wait.'
   echo "DEBUG SYS_CORES_COUNT: ${SYS_CORES_COUNT}"
   echo "DEBUG SYS_CORES_PLUS_ONE: ${SYS_CORES_PLUS_ONE}"
-  make --jobs "${SYS_CORES_PLUS_ONE}"
+  make -j${SYS_CORES_PLUS_ONE}
   log_info 'Running compile checks. Please wait.'
-  make --jobs "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
+  make -j "${SYS_CORES_PLUS_ONE}" check > /dev/null 2> "${STDERR_COMPILE_LOG_FILE}"
   # exclude the two lines before and after 'Ran 3 tests in ' in make check's stdout
   sed -n '1N;2N;/Ran 3 tests in /{N;N;d;};P;N;D' "${STDERR_COMPILE_LOG_FILE}" >&2
   log_info 'Installing Bitcoin Core.'

--- a/nodebuilder
+++ b/nodebuilder
@@ -94,7 +94,11 @@ compile_bitcoin_from_source() {
   # exclude the two lines before and after 'Ran 3 tests in ' in make check's stdout
   sed -n '1N;2N;/Ran 3 tests in /{N;N;d;};P;N;D' "${STDERR_COMPILE_LOG_FILE}" >&2
   log_info 'Installing Bitcoin Core.'
-  make install > /dev/null 2>&1 || sudo make install > /dev/null
+  if [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then
+    gmake install > /dev/null 2>&1 || sudo gmake install > /dev/null
+  else
+    make install > /dev/null 2>&1 || sudo make install > /dev/null
+  fi
   cd - > /dev/null
   rm "${STDERR_COMPILE_LOG_FILE}"
   rm -rf "${COMPILE_DIRECTORY:?}"/

--- a/resources/dependencies/build_dependencies_freebsd.txt
+++ b/resources/dependencies/build_dependencies_freebsd.txt
@@ -9,5 +9,6 @@ libzmq4
 pkgconf
 python3
 sqlite3
+qt5-buildtools
 qt5-gui
 qt5-widgets

--- a/resources/dependencies/build_dependencies_freebsd.txt
+++ b/resources/dependencies/build_dependencies_freebsd.txt
@@ -11,4 +11,5 @@ python3
 sqlite3
 qt5-buildtools
 qt5-gui
+qt5-linguisttools
 qt5-widgets

--- a/resources/dependencies/build_dependencies_freebsd.txt
+++ b/resources/dependencies/build_dependencies_freebsd.txt
@@ -5,7 +5,7 @@ gmake
 libevent
 libqrencode
 libtool
-libzmq
+libzmq4
 pkgconf
 python3
 sqlite3

--- a/resources/dependencies/build_dependencies_freebsd.txt
+++ b/resources/dependencies/build_dependencies_freebsd.txt
@@ -10,3 +10,4 @@ pkgconf
 python3
 sqlite3
 qt5-gui
+qt5-widgets

--- a/resources/dependencies/build_dependencies_freebsd.txt
+++ b/resources/dependencies/build_dependencies_freebsd.txt
@@ -1,6 +1,7 @@
 autoconf
 automake
 boost-libs
+gettext
 gmake
 libevent
 libqrencode

--- a/resources/dependencies/runtime_dependencies_freebsd.txt
+++ b/resources/dependencies/runtime_dependencies_freebsd.txt
@@ -3,6 +3,4 @@ git
 gnupg
 gzip
 jq
-procps
 sudo
-tar

--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -7,7 +7,7 @@ set -o errexit
 set -o nounset
 
 get_operating_system() {
-  case "${TARGET_KERNEL}"
+  case "${TARGET_KERNEL}" in
   Darwin | FreeBSD)
     printf '%s\n' "${TARGET_KERNEL}"
     ;;

--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -7,9 +7,10 @@ set -o errexit
 set -o nounset
 
 get_operating_system() {
-  if [ "${TARGET_KERNEL}" = 'Darwin' ] || [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then
+  case "${TARGET_KERNEL}"
+  Darwin | FreeBSD)
     printf '%s\n' "${TARGET_KERNEL}"
-  else
+  *)
     readonly OS_RELEASE_ID_LIKE="$(grep '^ID_LIKE=' /etc/os-release | cut -d= -f2)"
     readonly OS_RELEASE_ID="$(grep '^ID=' /etc/os-release | cut -d= -f2)"
 
@@ -18,7 +19,7 @@ get_operating_system() {
     else
       throw_error 'Failed to determine OS release type'
     fi
-  fi
+  esac
 }
 
 handle_exit() {

--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -291,13 +291,11 @@ if [ "${TARGET_KERNEL}" != 'Darwin' ]; then
 fi
 
 if [ "${TARGET_KERNEL}" = 'Linux' ]; then
-  for message in \
-    'Checking system memory... [0-9]+\.[0-9] of [0-9]+\.[0-9] GiB free.$'; do
-    if ! grep -Eq "${message}" test_output_stdout.txt > /dev/null 2>&1; then
-      printf '%s\n' "FAILURE: Expected message ${message} not found."
-      exit 1
-    fi
-  done
+  message='Checking system memory... [0-9]+\.[0-9] of [0-9]+\.[0-9] GiB free.$'
+  if ! grep -Eq "${message}" test_output_stdout.txt > /dev/null 2>&1; then
+    printf '%s\n' "FAILURE: Expected message ${message} not found."
+    exit 1
+  fi
 fi
 
 printf '%s\n' 'PASS: All console output tests passed.'

--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -243,7 +243,7 @@ for message in \
 done
 
 if [ "${COMPILE_BITCOIN}" = 'true' ] ||
-  [ "${TARGET_KERNEL"} = 'FreeBSD' ] ||
+  [ "${TARGET_KERNEL}" = 'FreeBSD' ] ||
   { [ -f /etc/os-release ] && [ "${TARGET_OPERATING_SYSTEM}" = 'alpine' ]; }; then
   for message in \
     'INFO: Ensuring compile dependencies.$' \

--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -10,6 +10,7 @@ get_operating_system() {
   case "${TARGET_KERNEL}"
   Darwin | FreeBSD)
     printf '%s\n' "${TARGET_KERNEL}"
+    ;;
   *)
     readonly OS_RELEASE_ID_LIKE="$(grep '^ID_LIKE=' /etc/os-release | cut -d= -f2)"
     readonly OS_RELEASE_ID="$(grep '^ID=' /etc/os-release | cut -d= -f2)"
@@ -19,6 +20,7 @@ get_operating_system() {
     else
       throw_error 'Failed to determine OS release type'
     fi
+    ;;
   esac
 }
 

--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -7,8 +7,8 @@ set -o errexit
 set -o nounset
 
 get_operating_system() {
-  if [ "${TARGET_KERNEL}" = 'Darwin' ]; then
-    printf '%s\n' 'Darwin'
+  if [ "${TARGET_KERNEL}" = 'Darwin' ] || [ "${TARGET_KERNEL}" = 'FreeBSD' ]; then
+    printf '%s\n' "${TARGET_KERNEL}"
   else
     readonly OS_RELEASE_ID_LIKE="$(grep '^ID_LIKE=' /etc/os-release | cut -d= -f2)"
     readonly OS_RELEASE_ID="$(grep '^ID=' /etc/os-release | cut -d= -f2)"
@@ -139,7 +139,7 @@ readonly NODEBUILDER_BINARY_URL="${NODEBUILDER_REPO_URL}/raw/${GIT_REF_SHORT_NAM
 
 case "${TARGET_KERNEL}" in
 Darwin) bitcoin_data_directory="${HOME}/Library/Application Support/Bitcoin" ;;
-Linux) bitcoin_data_directory="${HOME}/.bitcoin" ;;
+Linux | FreeBSD) bitcoin_data_directory="${HOME}/.bitcoin" ;;
 MINGW*) throw_error 'Windows is not supported.' ;;
 *) throw_error 'Your operating system is not supported.' ;;
 esac

--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -111,7 +111,7 @@ while [ $# -gt 0 ]; do
   -r | --ref)
     [ -z "$2" ] && throw_error 'No argument supplied for -r|--ref.' "${LINENO}"
     readonly GIT_REF_SHORT_NAME="$2"
-    validate_git_ref_short_name "${GIT_REF_SHORT_NAME}"
+    [ "$(uname -s)" = 'FreeBSD' ] || validate_git_ref_short_name "${GIT_REF_SHORT_NAME}"
     shift
     ;;
   *)

--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -202,7 +202,7 @@ if [ -s test_output_stderr.txt ]; then
 fi
 
 for message in \
-  'INFO: Detected: running (Linux|macOS).$' \
+  'INFO: Detected: running (Linux|macOS|FreeBSD).$' \
   'INFO: Checking for internet.$' \
   'INFO: Internet checks passed.$' \
   'INFO: (Failed to find|Found) Bitcoin Core [1-9][0-9]*\.[0-9]+(\.[0-9]+)?.$' \
@@ -243,6 +243,7 @@ for message in \
 done
 
 if [ "${COMPILE_BITCOIN}" = 'true' ] ||
+  [ "${TARGET_KERNEL"} = 'FreeBSD' ] ||
   { [ -f /etc/os-release ] && [ "${TARGET_OPERATING_SYSTEM}" = 'alpine' ]; }; then
   for message in \
     'INFO: Ensuring compile dependencies.$' \
@@ -281,7 +282,16 @@ fi
 if [ "${TARGET_KERNEL}" != 'Darwin' ]; then
   for message in \
     'INFO: Ensuring runtime dependencies.$' \
-    'INFO: Creating application shortcuts.$' \
+    'INFO: Creating application shortcuts.$'; do
+    if ! grep -Eq "${message}" test_output_stdout.txt > /dev/null 2>&1; then
+      printf '%s\n' "FAILURE: Expected message ${message} not found."
+      exit 1
+    fi
+  done
+fi
+
+if [ "${TARGET_KERNEL}" = 'Linux' ]; then
+  for message in \
     'Checking system memory... [0-9]+\.[0-9] of [0-9]+\.[0-9] GiB free.$'; do
     if ! grep -Eq "${message}" test_output_stdout.txt > /dev/null 2>&1; then
       printf '%s\n' "FAILURE: Expected message ${message} not found."


### PR DESCRIPTION
## Describe the changes and your approach

- Add support for the FreeBSD kernel and OS
   - including runtime and compile dependencies
- Add a CI job to run nodebuilder on FreeBSD
   - with console output functional testing
   - save the `debug.log` as an artifact

## Pull Request Sign-Off

- I reviewed and approve of my changes.
- I checked of the [automated test results](https://github.com/bitcoin-tools/nodebuilder/actions) for any irregularities.
- If appropriate, I manually tested the code changes on my local environment.
- If appropriate, I considered changes to the [README](https://github.com/bitcoin-tools/nodebuilder/blob/master/README.md) or [test](https://github.com/bitcoin-tools/nodebuilder/blob/master/test/TEST.md) documentation.
