### PR TITLE
fix: only sign test_bitcoin if version is before 28.2

### DIFF
--- a/nodebuilder
+++ b/nodebuilder
@@ -402,7 +402,6 @@ is_arm64_test_bitcoin_signed()
 bitcoin_tarball_test()
 {
   log_info 'Running the unit tests.'
-  log_warning "DEBUG target_bitcoin_version=${target_bitcoin_version}"
   # only sign test_bitcoin if on arm64 and target version is before 28.2
   if [ "${TARGET_ARCHITECTURE}" = 'arm64' ] &&
     ! is_arm64_test_bitcoin_signed "${target_bitcoin_version}"; then


### PR DESCRIPTION
## Describe the changes and your approach

<!-- Answer here -->

## Pull Request Sign-Off

- I reviewed and approve of my changes.
- I checked of the [automated test results](https://github.com/bitcoin-tools/nodebuilder/actions) for any irregularities.
- If appropriate, I manually tested the code changes on my local environment.
- If appropriate, I considered changes to the [README](https://github.com/bitcoin-tools/nodebuilder/blob/master/README.md) or [test](https://github.com/bitcoin-tools/nodebuilder/blob/master/test/TEST.md) documentation.
