### PR TITLE
feat(portability): disable set -x during NetBSD nodebuilder test

### DIFF
--- a/test/test_nodebuilder
+++ b/test/test_nodebuilder
@@ -209,6 +209,11 @@ else
   readonly RUN_NODEBUILDER_COMMAND="./nodebuilder"
 fi
 
+# NetBSD has irregular behavior where set -x is applied to child
+#   processes too. This behavior seems to be non-POSIX, but to work
+#   around the issue, disable set -x during nodebuilder execution.
+[ "${TARGET_OPERATING_SYSTEM}" = 'NetBSD' ] && set +x
+
 # Execute the script with optional command line arguments
 printf 'Executing command: %s\n' "${RUN_NODEBUILDER_COMMAND}"
 if ! ${RUN_NODEBUILDER_COMMAND} \
@@ -216,6 +221,8 @@ if ! ${RUN_NODEBUILDER_COMMAND} \
   2> "${STDERR_TEST_FILENAME}"; then
   throw_error "Failed to execute nodebuilder command."
 fi
+
+[ "${TARGET_OPERATING_SYSTEM}" = 'NetBSD' ] && set -x
 
 # After the script runs successfully
 rm nodebuilder


### PR DESCRIPTION
…builder

## Describe the changes and your approach

<!-- Answer here -->

## Pull Request Sign-Off

- I reviewed and approve of my changes.
- I checked of the [automated test results](https://github.com/bitcoin-tools/nodebuilder/actions) for any irregularities.
- If appropriate, I manually tested the code changes on my local environment.
- If appropriate, I considered changes to the [README](https://github.com/bitcoin-tools/nodebuilder/blob/master/README.md) or [test](https://github.com/bitcoin-tools/nodebuilder/blob/master/test/TEST.md) documentation.
